### PR TITLE
Add support for the Pair ADT

### DIFF
--- a/src/ScillaContractDeployer.ts
+++ b/src/ScillaContractDeployer.ts
@@ -63,8 +63,7 @@ export class ScillaContract extends Contract {
 function handleParam(param:Field, arg:any, init_call:boolean = true):Value{
   if (typeof param.typeobject == 'undefined'){
     throw new HardhatPluginError("hardhat-scilla-plugin", "Parameters were incorrectly parsed. Try clearing your scilla.cache file.")
-  } else {
-    if (typeof param.typeobject == 'string'){
+  } else if (typeof param.typeobject == 'string'){
       if (init_call){
         return {
           vname: param.name,

--- a/src/ScillaContractDeployer.ts
+++ b/src/ScillaContractDeployer.ts
@@ -80,7 +80,7 @@ function handleParam(param:Field, arg:any, init_call:boolean = true):Value{
         values.push(handleParam(param, arg[index],false))
       });
       const argtypes2 = param.typeobject.argtypes.map((x)=>x.type);
-      if (init_call==true){
+      if (init_call){
         const value = JSON.parse(JSON.stringify({
           constructor: param.typeobject.ctor,
           argtypes: argtypes2,

--- a/src/ScillaParser.ts
+++ b/src/ScillaParser.ts
@@ -2,26 +2,28 @@ const parse: any = require("s-expression");
 import { execSync } from "child_process";
 import fs from "fs";
 
-type ScillaDataType = string;
+export const isNumeric = (type: string | ADTField) => {
+  if (typeof type == "string"){
+    switch (type) {
+      case "Int64":
+      case "Int128":
+      case "Int256":
+      case "Uint32":
+      case "Uint64":
+      case "Uint128":
+      case "Uint256":
+        return true;
 
-export const isNumeric = (type: ScillaDataType) => {
-  switch (type) {
-    case "Int64":
-    case "Int128":
-    case "Int256":
-    case "Uint32":
-    case "Uint64":
-    case "Uint128":
-    case "Uint256":
-      return true;
-
-    default:
-      return false;
+      default:
+        return false;
+    }
+  } else {
+    return false;
   }
 };
 
 export interface TransitionParam {
-  type: ScillaDataType;
+  type: string;
   name: string;
 }
 
@@ -32,8 +34,14 @@ export interface Transition {
 }
 
 export interface Field {
-  type: ScillaDataType;
+  typeobject?: string | ADTField;
   name: string;
+  type: string;
+}
+
+export interface ADTField{
+  ctor: string
+  argtypes: Field[]
 }
 
 export type Transitions = Transition[];
@@ -159,12 +167,9 @@ const extractTransitions = (ccompsElem: any[]): Transitions => {
     }
 
     const compParams = compParamsData[1].map((row: any[][][]) => {
-      const primType = row[1][1];
-      const primName = row[0][1][1];
-      return {
-        type: primType,
-        name: primName,
-      };
+      const param = parseField(row[1]);
+      param.name = row[0][1][1];
+      return param;
     });
     return {
       type: compType,
@@ -173,3 +178,31 @@ const extractTransitions = (ccompsElem: any[]): Transitions => {
     };
   });
 };
+
+function parseField(row : any):Field{
+  const field_type = row[0];
+
+  if (field_type == "PrimType"){
+    const type = row[1];
+    return {
+      name: "",
+      typeobject: type,
+      type: type
+    }
+  } else if (field_type == "ADT"){
+    const ctor = row[1][1][1];
+    const argtypes = row[2].map(parseField);
+    const name = row[0][1][1];
+    const ADT : ADTField = {
+      ctor: ctor,
+      argtypes: argtypes
+    }
+    return {
+      name: name,
+      typeobject: ADT,
+      type: ctor + argtypes.map((arg:Field)=>` (${arg.type})`).join('')
+    }
+  } else {
+    throw new Error(`Encountered unexpected field type ${row}`);
+  }
+}

--- a/src/ScillaParser.ts
+++ b/src/ScillaParser.ts
@@ -1,4 +1,5 @@
 const parse: any = require("s-expression");
+import { HardhatPluginError } from "hardhat/plugins";
 import { execSync } from "child_process";
 import fs from "fs";
 
@@ -34,7 +35,7 @@ export interface Transition {
 }
 
 export interface Field {
-  typeobject?: string | ADTField;
+  typeJSON?: string | ADTField; //Type in JSON format.
   name: string;
   type: string;
 }
@@ -186,7 +187,7 @@ function parseField(row : any):Field{
     const type = row[1];
     return {
       name: "",
-      typeobject: type,
+      typeJSON: type,
       type: type
     }
   } else if (field_type == "ADT"){
@@ -199,8 +200,8 @@ function parseField(row : any):Field{
     }
     return {
       name: name,
-      typeobject: ADT,
-      type: ctor + argtypes.map((arg:Field)=>` (${arg.type})`).join('')
+      typeJSON: ADT,
+      type: ctor + " " + argtypes.map((arg: Field) => arg.type).join(' ')
     }
   } else {
     throw new HardhatPluginError("hardhat-scilla-plugin", `Encountered unexpected field type ${row}`);

--- a/src/ScillaParser.ts
+++ b/src/ScillaParser.ts
@@ -203,6 +203,6 @@ function parseField(row : any):Field{
       type: ctor + argtypes.map((arg:Field)=>` (${arg.type})`).join('')
     }
   } else {
-    throw new HardhatPluginError("hardhat-scilla-plugin", Encountered unexpected field type ${row}`);
+    throw new HardhatPluginError("hardhat-scilla-plugin", `Encountered unexpected field type ${row}`);
   }
 }

--- a/src/ScillaParser.ts
+++ b/src/ScillaParser.ts
@@ -203,6 +203,6 @@ function parseField(row : any):Field{
       type: ctor + argtypes.map((arg:Field)=>` (${arg.type})`).join('')
     }
   } else {
-    throw new Error(`Encountered unexpected field type ${row}`);
+    throw new HardhatPluginError("hardhat-scilla-plugin", Encountered unexpected field type ${row}`);
   }
 }

--- a/test/scilla-contracs-updater.test.ts
+++ b/test/scilla-contracs-updater.test.ts
@@ -51,7 +51,7 @@ describe("", function () {
 
     it("Should have correct transitions parameters for setHello", function () {
       expect(helloContract.parsedContract.transitions[0].params).to.deep.eq([
-        { type: "String", name: "msg" },
+        { type: "String", name: "msg", typeobject: "String" },
       ]);
     });
 

--- a/test/scilla-parser.test.ts
+++ b/test/scilla-parser.test.ts
@@ -31,7 +31,7 @@ describe("", function () {
 
     it("Should have correct transitions parameters for setHello", function () {
       expect(contract.transitions[0].params).to.deep.eq([
-        { type: "String", name: "msg" },
+        { type: "String", name: "msg" , typeobject: "String"},
       ]);
     });
 


### PR DESCRIPTION
Can now call transitions that use pairs by supplying a list with the parameters in them. This supports nesting ie Pair(Pair(3,4),5) is represented as [[3,4],5] in typescript.