### PR TITLE
(feat) #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,8 @@ typings/
 
 # environment variables
 .env
+
+# Emacs backups
+*~
+\#*
+.\#*

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ await contract.Set(12);
 
 ### Get field value
 
-If a given contract has a filed named `msg` is possible to get its current value using a function call to `msg()`
+If a given contract has a field named `msg` is possible to get its current value using a function call to `msg()`
 
 ```typescript
 const msg = await contract.msg();

--- a/src/ScillaContractDeployer.ts
+++ b/src/ScillaContractDeployer.ts
@@ -1,9 +1,13 @@
+// This is necessary so that tsc can resolve some of the indirect types for
+// sc_call, otherwise it errors out - richard@zilliqa.com 2023-03-09
+import { Transaction } from "@zilliqa-js/account";
 import { Contract, Init, Value } from "@zilliqa-js/contract";
 import { BN, bytes, Long, units } from "@zilliqa-js/util";
 import { Zilliqa } from "@zilliqa-js/zilliqa";
 import fs from "fs";
 import { HardhatPluginError } from "hardhat/plugins";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { stringifyTransactionErrors } from "./ZilliqaUtils";
 
 import { ContractInfo } from "./ScillaContractsInfoUpdater";
 import { Fields, isNumeric, TransitionParam } from "./ScillaParser";
@@ -19,18 +23,23 @@ export interface Setup {
 
 export let setup: Setup | null = null;
 
+// The optional params are listed in popularity order.
 export const initZilliqa = (
-  zilliqaNetworkUrl: string,
-  chainId: number,
-  privateKeys: string[]
+    zilliqaNetworkUrl: string,
+    chainId: number,
+    privateKeys: string[],
+    attempts: number = 10,
+    timeoutMs: number = 1000,
+    gasPriceQa: number = 2000,
+    gasLimit: number = 50000,
 ): Setup => {
   setup = {
     zilliqa: new Zilliqa(zilliqaNetworkUrl),
     version: bytes.pack(chainId, 1),
-    gasPrice: units.toQa("2000", units.Units.Li),
-    gasLimit: Long.fromNumber(50000),
-    attempts: 10,
-    timeout: 1000,
+    gasPrice: units.toQa(gasPriceQa.toString(), units.Units.Li),
+    gasLimit: Long.fromNumber(gasLimit),
+    attempts: attempts,
+    timeout: timeoutMs,
   };
 
   privateKeys.forEach((pk) => setup!.zilliqa.wallet.addByPrivateKey(pk));
@@ -60,13 +69,15 @@ export async function deploy(
   }
 
   let sc: ScillaContract;
+  let tx: Transaction;
   const init: Init = fillInit(
     contractName,
     contractInfo.parsedContract.constructorParams,
     ...args
   );
 
-  sc = await deploy_from_file(contractInfo.path, init);
+  [tx,sc] = await deploy_from_file(contractInfo.path, init);
+  sc['deployed_by'] = tx
   contractInfo.parsedContract.transitions.forEach((transition) => {
     sc[transition.name] = async (...args: any[]) => {
       let amount = 0;
@@ -142,7 +153,7 @@ const fillInit = (
 async function deploy_from_file(
   path: string,
   init: Init
-): Promise<ScillaContract> {
+): Promise<[Transaction, ScillaContract]> {
   if (setup === null) {
     throw new HardhatPluginError(
       "hardhat-scilla-plugin",
@@ -152,14 +163,18 @@ async function deploy_from_file(
 
   const code = read(path);
   const contract = setup.zilliqa.contracts.new(code, init);
-  const [_, sc] = await contract.deploy(
+  const [tx, sc] = await contract.deploy(
     { ...setup },
     setup.attempts,
     setup.timeout,
     false
   );
 
-  return sc;
+    if (!sc.isDeployed()) {
+        let txnErrors = stringifyTransactionErrors(tx);
+        throw new Error(`Scilla contract was not deployed - status ${sc.status} from ${tx.id}, errors: ${txnErrors}`)
+  }
+  return [tx, sc];
 }
 
 // call a smart contract's transition with given args and an amount to send from a given public key

--- a/src/ScillaContractDeployer.ts
+++ b/src/ScillaContractDeployer.ts
@@ -172,7 +172,7 @@ async function deploy_from_file(
 
     if (!sc.isDeployed()) {
         let txnErrors = stringifyTransactionErrors(tx);
-        throw new Error(`Scilla contract was not deployed - status ${sc.status} from ${tx.id}, errors: ${txnErrors}`)
+        throw new HardhatPluginError(`Scilla contract was not deployed - status ${sc.status} from ${tx.id}, errors: ${txnErrors}`)
   }
   return [tx, sc];
 }

--- a/src/ZilliqaUtils.ts
+++ b/src/ZilliqaUtils.ts
@@ -1,0 +1,41 @@
+import { TransactionError } from "@zilliqa-js/core";
+import { Transaction } from "@zilliqa-js/account";
+
+interface ErrorDict {
+    [index: string]: TransactionError[];
+}
+
+/** Given a transaction, return a string[][] array containing a list of errors, decoded into their
+ * symbolic values, for each level of the transaction.
+ */
+export function decodeTransactionErrors(txn : Transaction) : string[][] {
+    let receipt = txn.getReceipt();
+    if (receipt === undefined) {
+        return [ ]
+    }
+    if (receipt.errors === undefined) {
+        return [ ]
+    }
+    var rv : string[][] = [ ]
+    var errors = (receipt.errors as ErrorDict)
+    for (let key in errors) {
+        var our_errors : string[] = []
+        for (let err in errors[key]) {
+            our_errors.push(`${err} (${TransactionError[err]})`)
+        }
+        rv.push(our_errors)
+    }
+    return rv
+}
+
+/** Given a transaction, get the errors from the receipt and return a human-readable string that
+ *  can be used to display them.
+ */
+export function stringifyTransactionErrors(txn : Transaction): string {
+    let errors : string[][] = decodeTransactionErrors(txn)
+    let result = ""
+    for (let level in errors) {
+        result = result + "[" + errors[level].join(",") + "] "
+    }
+    return result
+}


### PR DESCRIPTION
 * contracts that fail to deploy now throw, with an explanatory error message.
 * it's now possible to obtain the transaction id (and other data) from a contract deployment
 * you can now specify attempts, gas params, etc. for the Zilliqa provider object