### PR TITLE
Remove import as we want Value defined differently

### DIFF
--- a/src/ScillaContractDeployer.ts
+++ b/src/ScillaContractDeployer.ts
@@ -1,7 +1,7 @@
 // This is necessary so that tsc can resolve some of the indirect types for
 // sc_call, otherwise it errors out - richard@zilliqa.com 2023-03-09
 import { Transaction } from "@zilliqa-js/account";
-import { Contract, Init, Value } from "@zilliqa-js/contract";
+import { Contract, Init } from "@zilliqa-js/contract";
 import { BN, bytes, Long, units } from "@zilliqa-js/util";
 import { Zilliqa } from "@zilliqa-js/zilliqa";
 import fs from "fs";


### PR DESCRIPTION
Previous merge did not resolve conflict correctly. We do not want to import the Value type as we use a slightly different definition.