### PR TITLE
add support for using the plugin with multiple accounts

### DIFF
--- a/src/ScillaContractDeployer.ts
+++ b/src/ScillaContractDeployer.ts
@@ -72,6 +72,16 @@ function read(f: string) {
   return t;
 }
 
+export function setAccount(accountNumber:number){
+  if (setup === null) {
+    throw new HardhatPluginError(
+      "hardhat-scilla-plugin",
+      "Please call initZilliqa function."
+    );
+  }
+  setup.zilliqa.wallet.defaultAccount = setup.accounts[accountNumber];
+}
+
 export type ContractFunction<T = any> = (...args: any[]) => Promise<T>;
 
 export class ScillaContract extends Contract {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import "./task-extensions";
 // extensions in your npm package's types file.
 import "./type-extensions";
 
-export { ScillaContract, initZilliqa, Setup } from "./ScillaContractDeployer";
+export { ScillaContract, Setup , initZilliqa, setAccount} from "./ScillaContractDeployer";
 
 export { scillaChaiEventMatcher } from "./ScillaChaiMatchers";
 


### PR DESCRIPTION
You can choose which of the accounts you gave to the initZilliqa function you want to use to sign the transaction by calling setAccount and providing its corresponing number (0-indexing!)