### PR TITLE
Add event logs translators to have easier chai matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ But if you just want to expect on the value of a event parameter do this:
 expect(tx).to.have.eventLogWithParams("getHello()", {value: "hello world"});
 ```
 
+For easier value matching, some value conversions are done under the hood.
+* 32/64 bit integer values are converted to `Number`
+* 128/256 bit integer values are converted to `BigNumber`
+* `Option` is converted to its inner value if exists any, or `null` otherwise.
+* `Bool` is converted to underlying boolean value.
+ 
 for more tests please take look at [scilla tests](https://github.com/Zilliqa/Zilliqa/tree/master/tests/EvmAcceptanceTests/test/scilla).
 
 ### TODO

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-scilla-plugin",
-  "version": "2.2.1",
+  "version": "2.3.1",
   "description": "Hardhat TypeScript plugin for scilla testing",
   "repository": "github:Zilliqa/hardhat-scilla-plugin",
   "author": "Saeed Dadkhah",
@@ -32,6 +32,7 @@
     "README.md"
   ],
   "devDependencies": {
+    "@ethersproject/bignumber": "^5.7.0",
     "@types/chai": "^4.1.7",
     "@types/chai-subset": "^1.3.3",
     "@types/cli-color": "^2.0.2",

--- a/src/LogsSimplifier.ts
+++ b/src/LogsSimplifier.ts
@@ -1,25 +1,24 @@
-import {BigNumber} from "@ethersproject/bignumber"
+import { BigNumber } from "@ethersproject/bignumber";
+
 import { isNumeric } from "./ScillaParser";
 
-export const simplifyLogs = function(logs: any) {
-  for (let log of logs) {
+export const simplifyLogs = function (logs: any) {
+  for (const log of logs) {
     log.params.forEach((param: any) => {
       if (isNumeric(param.type)) {
-        param.value = simplifyNumber(param.type, param.value)
-      }
-      else if (param.type.startsWith("Option")) {
-        param = simplifyOption(param)
-      }
-      else if (param.type === "Bool") {
-        param = simplifyBool(param)
+        param.value = simplifyNumber(param.type, param.value);
+      } else if (param.type.startsWith("Option")) {
+        param = simplifyOption(param);
+      } else if (param.type === "Bool") {
+        param = simplifyBool(param);
       }
     });
   }
 
   return logs;
-}
+};
 
-const simplifyNumber = function(type: string, n: string) {
+const simplifyNumber = function (type: string, n: string) {
   switch (type) {
     case "Uint32":
     case "Int64":
@@ -31,31 +30,31 @@ const simplifyNumber = function(type: string, n: string) {
     case "Uint128":
     case "Uint256":
       return BigNumber.from(n);
-  
+
     default:
       break;
   }
 
   return n;
-}
+};
 
-const simplifyOption = function(param: any) {
+const simplifyOption = function (param: any) {
   const constr = param.value.constructor;
   if (constr === "None") {
-    param.value = null
+    param.value = null;
   } else {
-    const innerType = param.value.argtypes[0]
-    const innerValue = param.value.arguments[0]
+    const innerType = param.value.argtypes[0];
+    const innerValue = param.value.arguments[0];
     if (isNumeric(innerType)) {
-      param.value = simplifyNumber(innerType, innerValue)
+      param.value = simplifyNumber(innerType, innerValue);
     }
   }
 
   return param;
-}
+};
 
-const simplifyBool = function(param: any) {
+const simplifyBool = function (param: any) {
   const constr = param.value.constructor;
-  param.value = (constr === "True" ? true : false)
+  param.value = constr === "True" ? true : false;
   return param;
-}
+};

--- a/src/LogsSimplifier.ts
+++ b/src/LogsSimplifier.ts
@@ -1,0 +1,61 @@
+import {BigNumber} from "@ethersproject/bignumber"
+import { isNumeric } from "./ScillaParser";
+
+export const simplifyLogs = function(logs: any) {
+  for (let log of logs) {
+    log.params.forEach((param: any) => {
+      if (isNumeric(param.type)) {
+        param.value = simplifyNumber(param.type, param.value)
+      }
+      else if (param.type.startsWith("Option")) {
+        param = simplifyOption(param)
+      }
+      else if (param.type === "Bool") {
+        param = simplifyBool(param)
+      }
+    });
+  }
+
+  return logs;
+}
+
+const simplifyNumber = function(type: string, n: string) {
+  switch (type) {
+    case "Uint32":
+    case "Int64":
+    case "Uint64":
+      return Number(n);
+    case "Uint128":
+    case "Int128":
+    case "Int256":
+    case "Uint128":
+    case "Uint256":
+      return BigNumber.from(n);
+  
+    default:
+      break;
+  }
+
+  return n;
+}
+
+const simplifyOption = function(param: any) {
+  const constr = param.value.constructor;
+  if (constr === "None") {
+    param.value = null
+  } else {
+    const innerType = param.value.argtypes[0]
+    const innerValue = param.value.arguments[0]
+    if (isNumeric(innerType)) {
+      param.value = simplifyNumber(innerType, innerValue)
+    }
+  }
+
+  return param;
+}
+
+const simplifyBool = function(param: any) {
+  const constr = param.value.constructor;
+  param.value = (constr === "True" ? true : false)
+  return param;
+}

--- a/src/ScillaChaiMatchers.ts
+++ b/src/ScillaChaiMatchers.ts
@@ -1,6 +1,7 @@
 import { Transaction } from "@zilliqa-js/account";
 import chai from "chai";
 import chaiSubset from "chai-subset";
+
 import { simplifyLogs } from "./LogsSimplifier";
 chai.use(chaiSubset);
 
@@ -50,7 +51,9 @@ export const scillaChaiEventMatcher = function (
     new Assertion(this._obj).to.eventLog(eventName);
 
     const event_logs = simplifyLogs(receipt.event_logs!);
-    const desiredLog = event_logs.filter((log: any) => log._eventname === eventName);
+    const desiredLog = event_logs.filter(
+      (log: any) => log._eventname === eventName
+    );
 
     new Assertion(desiredLog[0].params).to.containSubset(params);
   });

--- a/src/ScillaChaiMatchers.ts
+++ b/src/ScillaChaiMatchers.ts
@@ -8,7 +8,7 @@ chai.use(chaiSubset);
 
 export interface EventParam {
   type?: string;
-  value?: string | BigNumber | number;
+  value?: string | BigNumber | number | boolean;
   vname?: string;
 }
 

--- a/src/ScillaChaiMatchers.ts
+++ b/src/ScillaChaiMatchers.ts
@@ -1,3 +1,4 @@
+import { BigNumber } from "@ethersproject/bignumber";
 import { Transaction } from "@zilliqa-js/account";
 import chai from "chai";
 import chaiSubset from "chai-subset";
@@ -7,7 +8,7 @@ chai.use(chaiSubset);
 
 export interface EventParam {
   type?: string;
-  value?: string;
+  value?: string | BigNumber | number;
   vname?: string;
 }
 

--- a/src/ScillaChaiMatchers.ts
+++ b/src/ScillaChaiMatchers.ts
@@ -1,6 +1,7 @@
 import { Transaction } from "@zilliqa-js/account";
 import chai from "chai";
 import chaiSubset from "chai-subset";
+import { simplifyLogs } from "./LogsSimplifier";
 chai.use(chaiSubset);
 
 export interface EventParam {
@@ -48,8 +49,8 @@ export const scillaChaiEventMatcher = function (
     const receipt = tx.getReceipt()!;
     new Assertion(this._obj).to.eventLog(eventName);
 
-    const event_logs = receipt.event_logs!;
-    const desiredLog = event_logs.filter((log) => log._eventname === eventName);
+    const event_logs = simplifyLogs(receipt.event_logs!);
+    const desiredLog = event_logs.filter((log: any) => log._eventname === eventName);
 
     new Assertion(desiredLog[0].params).to.containSubset(params);
   });

--- a/test/logs-simplifier.test.ts
+++ b/test/logs-simplifier.test.ts
@@ -1,0 +1,138 @@
+import { expect } from "chai";
+import chai from "chai";
+
+import { simplifyLogs } from "../src/LogsSimplifier";
+import { BigNumber } from "@ethersproject/bignumber";
+
+describe("", function () {
+  describe("Scilla Parser should parse contracts successfully", function () {
+    before(function () {});
+
+    it("Should simplify integer strings to an integer for 32/64 bit ints", function () {
+      let log = [
+        {
+          _eventname: "Emit",
+          address: "0xb943f467a0159ee133618c1836a027ccecc62e28",
+          params: [
+            {
+              type: "ByStr20",
+              value: "0xec902fe17d90203d0bddd943d97b29576ece3177",
+              vname: "sender",
+            },
+            { type: "Uint64", value: "12", vname: "value" },
+          ],
+        },
+      ];
+      log = simplifyLogs(log);
+      expect(log[0].params[1].value).to.be.eq(12)
+    });
+
+    it("Should simplify integer strings to a BigNumber for big ints", function () {
+      let log = [
+        {
+          _eventname: "Emit",
+          address: "0xb943f467a0159ee133618c1836a027ccecc62e28",
+          params: [
+            { type: "Uint128", value: "12", vname: "value" },
+          ],
+        },
+      ];
+      let simpleLog = simplifyLogs(log);
+      let value: BigNumber = simpleLog[0].params[0].value;
+      expect(value.eq(BigNumber.from("12"))).to.be.true;
+    });
+
+    it("Should simplify Option data type to a more readable object if it has Some(int)", function () {
+      let log = [
+        {
+          _eventname: "TS",
+          address: "0x9ef9f1bbd1151a911962614d7fcdfdf5df45f401",
+          params: [
+            {
+              type: "Option (Uint64)",
+              value: {
+                argtypes: ["Uint64"],
+                arguments: ["123"],
+                constructor: "Some",
+              },
+              vname: "timestamp",
+            },
+          ],
+        },
+      ];
+
+      log = simplifyLogs(log);
+      expect(log[0].params[0].value).to.be.eq(123);
+    });
+
+    it("Should simplify Option data type to a null object if it's None", function () {
+      let log = [
+        {
+          _eventname: "TS",
+          address: "0x9ef9f1bbd1151a911962614d7fcdfdf5df45f401",
+          params: [
+            {
+              type: "Option (Uint64)",
+              value: {
+                argtypes: [],
+                arguments: [],
+                constructor: "None",
+              },
+              vname: "timestamp",
+            },
+          ],
+        },
+      ];
+
+      log = simplifyLogs(log);
+      expect(log[0].params[0].value).to.be.null;
+    });
+  
+    it("Should simplify Bool data type to true if it's True", function () {
+      let log = [
+        {
+          _eventname: "TS",
+          address: "0x9ef9f1bbd1151a911962614d7fcdfdf5df45f401",
+          params: [
+            {
+              type: "Bool",
+              value: {
+                argtypes: [],
+                arguments: [],
+                constructor: "True",
+              },
+              vname: "timestamp",
+            },
+          ],
+        },
+      ];
+
+      log = simplifyLogs(log);
+      
+      expect(log[0].params[0].value).to.be.true;
+    });
+
+    it("Should simplify Bool data type to true if it's True", function () {
+      let log = [
+        {
+          _eventname: "TS",
+          address: "0x9ef9f1bbd1151a911962614d7fcdfdf5df45f401",
+          params: [
+            {
+              type: "Bool",
+              value: {
+                argtypes: [],
+                arguments: [],
+                constructor: "False",
+              },
+              vname: "timestamp",
+            },
+          ],
+        },
+      ];
+
+      log = simplifyLogs(log);
+      expect(log[0].params[0].value).to.be.false;
+    });
+  });
+});

--- a/test/logs-simplifier.test.ts
+++ b/test/logs-simplifier.test.ts
@@ -1,8 +1,8 @@
+import { BigNumber } from "@ethersproject/bignumber";
 import { expect } from "chai";
 import chai from "chai";
 
 import { simplifyLogs } from "../src/LogsSimplifier";
-import { BigNumber } from "@ethersproject/bignumber";
 
 describe("", function () {
   describe("Scilla Parser should parse contracts successfully", function () {
@@ -24,21 +24,19 @@ describe("", function () {
         },
       ];
       log = simplifyLogs(log);
-      expect(log[0].params[1].value).to.be.eq(12)
+      expect(log[0].params[1].value).to.be.eq(12);
     });
 
     it("Should simplify integer strings to a BigNumber for big ints", function () {
-      let log = [
+      const log = [
         {
           _eventname: "Emit",
           address: "0xb943f467a0159ee133618c1836a027ccecc62e28",
-          params: [
-            { type: "Uint128", value: "12", vname: "value" },
-          ],
+          params: [{ type: "Uint128", value: "12", vname: "value" }],
         },
       ];
-      let simpleLog = simplifyLogs(log);
-      let value: BigNumber = simpleLog[0].params[0].value;
+      const simpleLog = simplifyLogs(log);
+      const value: BigNumber = simpleLog[0].params[0].value;
       expect(value.eq(BigNumber.from("12"))).to.be.true;
     });
 
@@ -87,7 +85,7 @@ describe("", function () {
       log = simplifyLogs(log);
       expect(log[0].params[0].value).to.be.null;
     });
-  
+
     it("Should simplify Bool data type to true if it's True", function () {
       let log = [
         {
@@ -108,7 +106,7 @@ describe("", function () {
       ];
 
       log = simplifyLogs(log);
-      
+
       expect(log[0].params[0].value).to.be.true;
     });
 


### PR DESCRIPTION
It was hard to expect `Bool` or `Option` values in events, but it isn't anymore! ;D

Here is how a boolean value looks like in the logs:

```      -    "type": "Bool"
      -    "value": {
      -      "argtypes": []
      -      "arguments": []
      -      "constructor": "False"
      -    }
      -    "vname": "b"
```

No it's translated to something like:
```
{
  "type": "Bool",
  "value": false,
  "vname": "b"
}
```

way easier to match using chai matchers.