### PR TITLE
Fix contract deployment backward compatibility problem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,7 @@ contract2 = await hre.deployScillaWithLib("TestContract2",
       [{name: "MutualLib", address: mutualLibAddress}]
 ```
 
-Optionally to change the deployer of the contract, you can send an instance of `Account` class to these functions.
-```typescript
-let contract: ScillaContract = await hre.deployScillaContract("SetGet", account);
-```
+To change the deployer of the contract, you can send an instance of `Account` class to `hre.setActiveAccount`.
 ### Call a transition
 
 It's not harder than calling a normal function in typescript.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-scilla-plugin",
-  "version": "3.4.6",
+  "version": "3.4.8",
   "description": "Hardhat TypeScript plugin for scilla testing",
   "repository": "github:Zilliqa/hardhat-scilla-plugin",
   "author": "Saeed Dadkhah",

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,10 +42,9 @@ extendEnvironment((hre) => {
   hre.deployScillaContract = lazyFunction(
     () => async (
       contractName: string,
-      deployer?: Account,
       ...args: any[]
     ): Promise<ScillaContract> => {
-      return deploy(hre, contractName, [], deployer, ...args);
+      return deploy(hre, contractName, [], ...args);
     }
   );
 
@@ -53,16 +52,15 @@ extendEnvironment((hre) => {
     () => async (
       contractName: string,
       userDefinedLibraries: UserDefinedLibrary[],
-      deployer?: Account,
       ...args: any[]
     ): Promise<ScillaContract> => {
-      return deploy(hre, contractName, userDefinedLibraries, deployer, ...args);
+      return deploy(hre, contractName, userDefinedLibraries, ...args);
     }
   );
 
   hre.deployScillaLibrary = lazyFunction(
-    () => async (libraryName: string, deployer?: Account): Promise<ScillaContract> => {
-      return deployLibrary(hre, libraryName, deployer);
+    () => async (libraryName: string): Promise<ScillaContract> => {
+      return deployLibrary(hre, libraryName);
     }
   );
 
@@ -70,9 +68,8 @@ extendEnvironment((hre) => {
     () => async (
       contractPath: string,
       init: Init,
-      deployer?: Account
     ): Promise<[Transaction, ScillaContract]> => {
-      return deployFromFile(contractPath, init, deployer);
+      return deployFromFile(contractPath, init);
     }
   );
 

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -16,20 +16,17 @@ declare module "hardhat/types/runtime" {
     scillaContracts: ScillaContracts;
     deployScillaContract: (
       contractName: string,
-      deployer?: Account,
       ...args: any[]
     ) => Promise<ScillaContract>;
     deployScillaContractWithLib: (
       contractName: string,
       userDefinedLibraries: UserDefinedLibrary[],
-      deployer?: Account,
       ...args: any[]
     ) => Promise<ScillaContract>;
-    deployScillaLibrary: (contractName: string, deployer?: Account) => Promise<ScillaContract>;
+    deployScillaLibrary: (contractName: string) => Promise<ScillaContract>;
     deployScillaFile: (
       contractName: string,
-      init: Init,
-      deployer?: Account
+      init: Init
     ) => Promise<[Transaction, ScillaContract]>;
     zilliqa: ZilliqaHardhatObject;
     getZilliqaChainId: () => number;


### PR DESCRIPTION
Actually, we don't need any new API. We already have `setActiveAccount` and we can use it for contract deployment. I couldn't find any cleaner API than `setActiveAccount` for now to be backward-compatible. Although we have `.connect(signer)` function to change the contract transition executer, let's stick with `setActiveAccount` for now and maybe have a better API for the future.